### PR TITLE
removing BukkitTelnet from untouchable plugins

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_plugincontrol.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_plugincontrol.java
@@ -18,7 +18,7 @@ import org.bukkit.plugin.PluginManager;
 public class Command_plugincontrol extends FreedomCommand
 {
 
-    private final List<String> UNTOUCHABLE_PLUGINS = Arrays.asList(plugin.getName(), "BukkitTelnet");
+    private final List<String> UNTOUCHABLE_PLUGINS = Arrays.asList(plugin.getName());
 
     @Override
     public boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)


### PR DESCRIPTION
causes unneccessary inconveniences to have it untouchable, and there are no issues when it is reloaded (besides kicking people out of telnet - which isn't a huge problem)