### PR TITLE
Fixed permission not setting for new players (FS-93)

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_deop.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_deop.java
@@ -40,6 +40,7 @@ public class Command_deop extends FreedomCommand
                     matchedPlayerNames.add(player.getName());
                     player.setOp(false);
                     player.sendMessage(FreedomCommand.YOU_ARE_NOT_OP);
+                    plugin.rm.updateDisplay(player);
                 }
             }
         }

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_deopall.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_deopall.java
@@ -20,6 +20,7 @@ public class Command_deopall extends FreedomCommand
         {
             player.setOp(false);
             player.sendMessage(FreedomCommand.YOU_ARE_NOT_OP);
+            plugin.rm.updateDisplay(player);
         }
 
         return true;

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_op.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_op.java
@@ -41,6 +41,7 @@ public class Command_op extends FreedomCommand
                     matchedPlayerNames.add(player.getName());
                     player.setOp(true);
                     player.sendMessage(FreedomCommand.YOU_ARE_OP);
+                    plugin.rm.updateDisplay(player);
                 }
             }
         }

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_opall.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_opall.java
@@ -22,6 +22,7 @@ public class Command_opall extends FreedomCommand
             {
                 player.setOp(true);
                 player.sendMessage(FreedomCommand.YOU_ARE_OP);
+                plugin.rm.updateDisplay(player);
             }
         }
 

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_opme.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_opme.java
@@ -17,6 +17,7 @@ public class Command_opme extends FreedomCommand
         FUtil.adminAction(sender.getName(), "Opping " + sender.getName(), false);
         sender.setOp(true);
         sender.sendMessage(FreedomCommand.YOU_ARE_OP);
+        plugin.rm.updateDisplay(playerSender);
         return true;
     }
 }

--- a/src/main/java/me/totalfreedom/totalfreedommod/permissions/PermissionManager.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/permissions/PermissionManager.java
@@ -117,10 +117,4 @@ public class PermissionManager extends FreedomService
             setPermissions(player);
         }
     }
-
-    @EventHandler(priority = EventPriority.NORMAL)
-    public void onPlayerJoin(PlayerJoinEvent event)
-    {
-        setPermissions(event.getPlayer());
-    }
 }


### PR DESCRIPTION
- Players no longer need to relog, just need to be opped to get permissions.
- Removed redundant PlayerJoinEvent code as it's already been executed (See RankManager class).

I also added `RankManager#updateDisplay(Player)` to deop commands to prevent players from using what they shouldn't have access to.