### PR TITLE
Fix ban expiration (FS-147)

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/banning/Ban.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/banning/Ban.java
@@ -169,7 +169,7 @@ public class Ban
 
     public boolean isExpired()
     {
-        return hasExpiry() && expiryUnix < FUtil.getUnixTime();
+        return hasExpiry() && FUtil.getUnixDate(expiryUnix).before(new Date(FUtil.getUnixTime()));
     }
 
     public String bakeKickMessage()

--- a/src/main/java/me/totalfreedom/totalfreedommod/util/FUtil.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/util/FUtil.java
@@ -612,7 +612,7 @@ public class FUtil
 
     public static long getUnixTime()
     {
-        return Instant.now().getEpochSecond();
+        return Instant.now().toEpochMilli();
     }
 
     public static long getUnixTime(Date date)


### PR DESCRIPTION
I have changed the statement from checking long to checking the date and changed `getUnixTime()` to use `toEpochMilli()` instead of `getEpochSecond()` which resolves the expiration check.