### PR TITLE
Update JDA version and location (FS-145)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,9 +75,9 @@
         </repository>
 
         <repository>
-            <id>jcenter</id>
-            <name>jcenter-bintray</name>
-            <url>https://jcenter.bintray.com</url>
+            <id>dv8tion</id>
+            <name>m2-dv8tion</name>
+            <url>https://m2.dv8tion.net/releases/</url>
         </repository>
 
         <repository>
@@ -191,7 +191,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>4.2.0_224</version>
+            <version>4.2.1_255</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
To keep in line with Minecraft-JDA (see: https://github.com/AtlasMediaGroup/Minecraft-JDA/pull/3)

The version has been updated and the location has been changed (see FS-145)