### PR TITLE
Disables block gravity and makes it togglable (FS-89)

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/blocking/EventBlocker.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/blocking/EventBlocker.java
@@ -14,6 +14,7 @@ import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.block.data.AnaloguePowerable;
 import org.bukkit.block.data.Powerable;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.FallingBlock;
 import org.bukkit.entity.Tameable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -30,6 +31,7 @@ import org.bukkit.event.entity.EntityCombustEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.event.entity.EntitySpawnEvent;
 import org.bukkit.event.entity.ExplosionPrimeEvent;
 import org.bukkit.event.entity.FireworkExplodeEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -209,6 +211,18 @@ public class EventBlocker extends FreedomService
         if (!ConfigEntry.ALLOW_REDSTONE.getBoolean())
         {
             event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onEntitySpawn(EntitySpawnEvent event)
+    {
+        if (!ConfigEntry.ALLOW_GRAVITY.getBoolean())
+        {
+            if (event.getEntity() instanceof FallingBlock)
+            {
+                event.setCancelled(true);
+            }
         }
     }
 

--- a/src/main/java/me/totalfreedom/totalfreedommod/blocking/EventBlocker.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/blocking/EventBlocker.java
@@ -217,12 +217,9 @@ public class EventBlocker extends FreedomService
     @EventHandler
     public void onEntitySpawn(EntitySpawnEvent event)
     {
-        if (!ConfigEntry.ALLOW_GRAVITY.getBoolean())
+        if (!ConfigEntry.ALLOW_GRAVITY.getBoolean() && event.getEntity() instanceof FallingBlock)
         {
-            if (event.getEntity() instanceof FallingBlock)
-            {
-                event.setCancelled(true);
-            }
+            event.setCancelled(true);
         }
     }
 

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_toggle.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_toggle.java
@@ -54,6 +54,7 @@ public class Command_toggle extends FreedomCommand
             msg("- landmines");
             msg("- mp44");
             msg("- tossmob");
+            msg("- gravity");
             return false;
         }
 
@@ -297,6 +298,12 @@ public class Command_toggle extends FreedomCommand
                 toggle("Tossmob is", ConfigEntry.TOSSMOB_ENABLED);
                 break;
             }
+
+            case "gravity":
+            {
+                toggle("Block gravity is", ConfigEntry.ALLOW_GRAVITY);
+                break;
+            }
         }
         return true;
     }
@@ -320,7 +327,7 @@ public class Command_toggle extends FreedomCommand
                     "waterplace", "fireplace", "lavaplace", "fluidspread", "lavadmg", "firespread", "frostwalk",
                     "firework", "prelog", "lockdown", "petprotect", "entitywipe", "nonuke", "explosives", "unsafeenchs",
                     "bells", "armorstands", "structureblocks", "jigsaws", "grindstones", "jukeboxes", "spawners", "4chan", "beehives",
-                    "respawnanchors", "autotp", "autoclear", "minecarts", "mp44", "landmines", "tossmob");
+                    "respawnanchors", "autotp", "autoclear", "minecarts", "mp44", "landmines", "tossmob", "gravity");
         }
         return Collections.emptyList();
     }

--- a/src/main/java/me/totalfreedom/totalfreedommod/config/ConfigEntry.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/config/ConfigEntry.java
@@ -34,6 +34,7 @@ public enum ConfigEntry
     ALLOW_RESPAWN_ANCHORS(Boolean.class, "allow.respawnanchors"),
     AUTO_TP(Boolean.class, "allow.auto_tp"),
     AUTO_CLEAR(Boolean.class, "allow.auto_clear"),
+    ALLOW_GRAVITY(Boolean.class, "allow.gravity"),
     //
     BLOCKED_CHATCODES(String.class, "blocked_chatcodes"),
     //

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -226,6 +226,7 @@ allow:
   respawnanchors: false
   auto_tp: false
   auto_clear: false
+  gravity: false
 
 # Blocked commands:
 #


### PR DESCRIPTION
Admins can do /toggle gravity in-game if they wish to enable it, but by default it's disabled.