### PR TITLE
Why over-complicating things is a horrifically bad idea (/potion)

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_potion.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_potion.java
@@ -65,7 +65,7 @@ public class Command_potion extends FreedomCommand
                     Player target = playerSender;
                     if (args.length == 2)
                     {
-                        if (!plugin.al.isAdmin(sender) && !target.equals(getPlayer(sender.getName())))
+                        if (!plugin.al.isAdmin(sender) && !args[1].equalsIgnoreCase(sender.getName()))
                         {
                             msg(ChatColor.RED + "Only admins can clear potion effects from other players.");
                             return true;
@@ -104,7 +104,7 @@ public class Command_potion extends FreedomCommand
 
                     if (args.length == 5)
                     {
-                        if (!plugin.al.isAdmin(sender) && !getPlayer(args[4]).equals(getPlayer(sender.getName())))
+                        if (!plugin.al.isAdmin(sender) && !args[4].equalsIgnoreCase(sender.getName()))
                         {
                             msg("Only admins can apply potion effects to other players.", ChatColor.RED);
                             return true;


### PR DESCRIPTION
The longer I look into this plugin's code, the angrier I will become.

This fixes 2 bugs in the /potion command that I noticed:
- Fixes non-admins being able to clear other players
- Fixes NPE caused when trying to add potion effects to players who are not on the server as a non-admin.

Both of these issues are caused by over-complicating things, hence the name of this commit.