### PR TITLE
Logs even more punishment types (FS-239, FS-240, FS-241, FS-242)

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_blockcmd.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_blockcmd.java
@@ -1,6 +1,8 @@
 package me.totalfreedom.totalfreedommod.command;
 
 import me.totalfreedom.totalfreedommod.player.FPlayer;
+import me.totalfreedom.totalfreedommod.punishments.Punishment;
+import me.totalfreedom.totalfreedommod.punishments.PunishmentType;
 import me.totalfreedom.totalfreedommod.rank.Rank;
 import me.totalfreedom.totalfreedommod.util.FUtil;
 import org.bukkit.ChatColor;
@@ -75,9 +77,11 @@ public class Command_blockcmd extends FreedomCommand
         FPlayer playerdata = plugin.pl.getPlayer(player);
         if (!playerdata.allCommandsBlocked())
         {
-            playerdata.setCommandsBlocked(true);
             FUtil.adminAction(sender.getName(), "Blocking all commands for " + player.getName(), true);
+            playerdata.setCommandsBlocked(true);
             msg("Blocked commands for " + player.getName() + ".");
+
+            plugin.pul.logPunishment(new Punishment(player.getName(), FUtil.getIp(player), sender.getName(), PunishmentType.BLOCKCMD, null));
         }
         else
         {

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_blockedit.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_blockedit.java
@@ -1,6 +1,8 @@
 package me.totalfreedom.totalfreedommod.command;
 
 import me.totalfreedom.totalfreedommod.player.FPlayer;
+import me.totalfreedom.totalfreedommod.punishments.Punishment;
+import me.totalfreedom.totalfreedommod.punishments.PunishmentType;
 import me.totalfreedom.totalfreedommod.rank.Rank;
 import me.totalfreedom.totalfreedommod.util.FUtil;
 import org.apache.commons.lang.ArrayUtils;
@@ -128,6 +130,8 @@ public class Command_blockedit extends FreedomCommand
 
             msg(player2, "Your block modification abilities have been blocked.", ChatColor.RED);
             msg("Blocked all block modification abilities for " + player2.getName());
+
+            plugin.pul.logPunishment(new Punishment(player2.getName(), FUtil.getIp(player2), sender.getName(), PunishmentType.BLOCKEDIT, null));
         }
         return true;
     }

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_blockpvp.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_blockpvp.java
@@ -1,6 +1,8 @@
 package me.totalfreedom.totalfreedommod.command;
 
 import me.totalfreedom.totalfreedommod.player.FPlayer;
+import me.totalfreedom.totalfreedommod.punishments.Punishment;
+import me.totalfreedom.totalfreedommod.punishments.PunishmentType;
 import me.totalfreedom.totalfreedommod.rank.Rank;
 import me.totalfreedom.totalfreedommod.util.FUtil;
 import org.apache.commons.lang3.ArrayUtils;
@@ -125,6 +127,7 @@ public class Command_blockpvp extends FreedomCommand
             {
                 Command_smite.smite(sender, p, reason);
             }
+            plugin.pul.logPunishment(new Punishment(p.getName(), FUtil.getIp(p), sender.getName(), PunishmentType.BLOCKPVP, null));
 
             msg(p, "Your PVP has been disabled.", ChatColor.RED);
             msg("Disabled PVP for " + p.getName());

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_cage.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_cage.java
@@ -92,6 +92,15 @@ public class Command_cage extends FreedomCommand
             }
         }
 
+        if (outerMaterial == Material.PLAYER_HEAD)
+        {
+            FUtil.adminAction(sender.getName(), "Caging " + player.getName() + " in " + skullName, true);
+        }
+        else
+        {
+            FUtil.adminAction(sender.getName(), "Caging " + player.getName(), true);
+        }
+
         Location location = player.getLocation().clone().add(0.0, 1.0, 0.0);
 
         if (skullName != null)
@@ -102,17 +111,7 @@ public class Command_cage extends FreedomCommand
         {
             fPlayer.getCageData().cage(location, outerMaterial, innerMaterial);
         }
-
         player.setGameMode(GameMode.SURVIVAL);
-
-        if (outerMaterial == Material.PLAYER_HEAD)
-        {
-            FUtil.adminAction(sender.getName(), "Caging " + player.getName() + " in " + skullName, true);
-        }
-        else
-        {
-            FUtil.adminAction(sender.getName(), "Caging " + player.getName(), true);
-        }
 
         plugin.pul.logPunishment(new Punishment(player.getName(), FUtil.getIp(player), sender.getName(), PunishmentType.CAGE, null));
         return true;

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_cage.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_cage.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import me.totalfreedom.totalfreedommod.player.FPlayer;
+import me.totalfreedom.totalfreedommod.punishments.Punishment;
+import me.totalfreedom.totalfreedommod.punishments.PunishmentType;
 import me.totalfreedom.totalfreedommod.rank.Rank;
 import me.totalfreedom.totalfreedommod.util.FUtil;
 import org.bukkit.ChatColor;
@@ -111,6 +113,8 @@ public class Command_cage extends FreedomCommand
         {
             FUtil.adminAction(sender.getName(), "Caging " + player.getName(), true);
         }
+
+        plugin.pul.logPunishment(new Punishment(player.getName(), FUtil.getIp(player), sender.getName(), PunishmentType.CAGE, null));
         return true;
     }
 

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_orbit.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_orbit.java
@@ -1,6 +1,8 @@
 package me.totalfreedom.totalfreedommod.command;
 
 import me.totalfreedom.totalfreedommod.player.FPlayer;
+import me.totalfreedom.totalfreedommod.punishments.Punishment;
+import me.totalfreedom.totalfreedommod.punishments.PunishmentType;
 import me.totalfreedom.totalfreedommod.rank.Rank;
 import me.totalfreedom.totalfreedommod.util.FUtil;
 import org.bukkit.ChatColor;
@@ -56,11 +58,13 @@ public class Command_orbit extends FreedomCommand
             }
         }
 
+        FUtil.adminAction(sender.getName(), "Orbiting " + player.getName(), false);
+
         player.setGameMode(GameMode.SURVIVAL);
         playerdata.startOrbiting(strength);
-
         player.setVelocity(new Vector(0, strength, 0));
-        FUtil.adminAction(sender.getName(), "Orbiting " + player.getName(), false);
+
+        plugin.pul.logPunishment(new Punishment(player.getName(), FUtil.getIp(player), sender.getName(), PunishmentType.ORBIT, null));
         return true;
     }
 }

--- a/src/main/java/me/totalfreedom/totalfreedommod/punishments/PunishmentType.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/punishments/PunishmentType.java
@@ -8,5 +8,10 @@ public enum PunishmentType
     TEMPBAN,
     BAN,
     DOOM,
-    WARN
+    WARN,
+    CAGE,
+    BLOCKEDIT,
+    BLOCKPVP,
+    BLOCKCMD,
+    ORBIT
 }


### PR DESCRIPTION
Here's what I've changed:
- Adds /blockcmd to the punishment log (FS-239)
- Adds /blockedit and /blockpvp to the punishment log (FS-240)
- Adds /cage to the punishment log (FS-241)
- Adds /orbit to the punishment log (FS-242)
- Changes the order of operations in some commands to be a bit more consistent