### PR TITLE
Moved outstanding repo's to cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,62 +45,14 @@
             <url>https://atlasmedia.jfrog.io/artifactory/totalfreedom-development/</url>
         </repository>
 
-        <repository>
-            <id>CodeMC</id>
-            <url>https://repo.codemc.org/repository/maven-public/</url>
-        </repository>
-
-        <repository>
-            <id>nms-repo</id>
-            <url>https://repo.codemc.org/repository/nms/</url>
-        </repository>
-
-        <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-
-        <repository>
-            <id>enginehub</id>
-            <url>https://maven.enginehub.org/repo/</url>
-        </repository>
-
-        <repository>
-            <id>elmakers-repo</id>
-            <url>https://maven.elmakers.com/repository/</url>
-        </repository>
-
-        <repository>
-            <id>sk89q-snapshots</id>
-            <url>https://maven.sk89q.com/artifactory/repo</url>
-        </repository>
-
+        <!-- This one seems to be being a pain to move over as a Cache, not sure why -->
         <repository>
             <id>dv8tion</id>
             <name>m2-dv8tion</name>
             <url>https://m2.dv8tion.net/releases/</url>
         </repository>
 
-        <repository>
-            <id>playpro</id>
-            <url>https://maven.playpro.com/</url>
-        </repository>
-
-        <repository>
-            <id>md_5-public</id>
-            <url>https://repo.md-5.net/content/groups/public/</url>
-        </repository>
-
-        <repository>
-            <id>dmulloy2-repo</id>
-            <url>https://repo.dmulloy2.net/nexus/repository/public/</url>
-        </repository>
-
-        <repository>
-            <id>sk89q-repo</id>
-            <url>https://maven.sk89q.com/repo/</url>
-        </repository>
-
+        <!-- I also couldn't manage to get this one to easily move across, not 100% sure why -->
         <repository>
             <id>esentialsx-repo</id>
             <url>https://repo.essentialsx.net/releases/</url>


### PR DESCRIPTION
Some of these look like they were serving duplicate content anyway so this way at least we're down to 3 repo's, hopefully down to a single one in the future.