### PR TITLE
Two fixes (FS-421)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -429,8 +429,8 @@
                                     <include>org.reflections:reflections</include>
                                     <include>org.javassist:javassist</include>
                                     <include>io.papermc:paperlib</include>
-                                    <include>com.github.speedxx:Mojangson</include>
                                     <include>org.bstats:bstats-bukkit</include>
+                                    <include>org.bstats:bstats-base</include>
                                     <include>org.jetbrains:annotations</include>
                                 </includes>
                             </artifactSet>


### PR DESCRIPTION
This commits fixes two things:
- A minor oopsie I made when I removed Mojangson from the list of dependencies to rely on
- A critical oopsie someone else made which prevented the entire plugin from starting up correctly