### PR TITLE
Forces the server to recalculate the permissions server-wide in /opall (FS-256)

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_opall.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_opall.java
@@ -24,6 +24,10 @@ public class Command_opall extends FreedomCommand
                 msg(player, YOU_ARE_OP);
                 plugin.rm.updateDisplay(player);
             }
+            else
+            {
+                player.recalculatePermissions();
+            }
         }
 
         return true;


### PR DESCRIPTION
The problem /opall has is that it doesn't recalculate permissions for players who are marked as opped, only players who aren't.

The solution here is to simply force the server to recalculate permissions regardless of op status. setOp calls the method already, so there is no need to add the `player.recalculatePermissions()` in the "player is not opped" portion.

