### PR TITLE
Re-implement most-used commands from the old python bot & other improvements

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/ChatManager.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/ChatManager.java
@@ -175,15 +175,15 @@ public class ChatManager extends FreedomService
         });
     }
 
-    public void reportAction(Player reporter, Player reported, String report)
+    public void reportAction(Player reporter, String reportedName, String report)
     {
         for (Player player : server.getOnlinePlayers())
         {
             if (plugin.al.isAdmin(player))
             {
-                playerMsg(player, ChatColor.RED + "[REPORTS] " + ChatColor.GOLD + reporter.getName() + " has reported " + reported.getName() + " for " + report);
+                playerMsg(player, ChatColor.RED + "[REPORTS] " + ChatColor.GOLD + reporter.getName() + " has reported " + reportedName + " for " + report);
             }
         }
-        FLog.info("[REPORTS] " + reporter.getName() + " has reported " + reported.getName() + " for " + report);
+        FLog.info("[REPORTS] " + reporter.getName() + " has reported " + reportedName + " for " + report);
     }
 }

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_report.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_report.java
@@ -4,6 +4,7 @@ import me.totalfreedom.totalfreedommod.rank.Rank;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -22,36 +23,40 @@ public class Command_report extends FreedomCommand
         }
 
         Player player = getPlayer(args[0], true);
+        OfflinePlayer offlinePlayer = getOfflinePlayer(args[0]);
 
-        if (player == null)
+        if (player == null && offlinePlayer == null)
         {
             msg(PLAYER_NOT_FOUND);
             return true;
         }
-
-        if (sender instanceof Player)
+        else if (player != null)
         {
-            if (player.equals(playerSender))
+            if (sender instanceof Player)
             {
-                msg(ChatColor.RED + "Please, don't try to report yourself.");
+                if (player.equals(playerSender))
+                {
+                    msg(ChatColor.RED + "Please, don't try to report yourself.");
+                    return true;
+                }
+            }
+
+            if (plugin.al.isAdmin(player))
+            {
+                msg(ChatColor.RED + "You can not report admins.");
                 return true;
             }
-        }
 
-        if (plugin.al.isAdmin(player))
-        {
-            msg(ChatColor.RED + "You can not report admins.");
-            return true;
         }
 
         String report = StringUtils.join(ArrayUtils.subarray(args, 1, args.length), " ");
-        plugin.cm.reportAction(playerSender, player, report);
+        plugin.cm.reportAction(playerSender, (player == null) ? offlinePlayer.getName() : player.getName(), report);
 
         boolean logged = false;
 
         if (plugin.dc.enabled)
         {
-            logged = plugin.dc.sendReport(playerSender, player, report);
+            logged = (player == null) ? plugin.dc.sendReportOffline(playerSender, offlinePlayer, report) : plugin.dc.sendReport(playerSender, player, report);
         }
 
         msg(ChatColor.GREEN + "Thank you, your report has been successfully logged."

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_vanish.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_vanish.java
@@ -45,7 +45,7 @@ public class Command_vanish extends FreedomCommand
                 msg("You have unvanished.", ChatColor.GOLD);
                 FUtil.bcastMsg(plugin.rm.craftLoginMessage(playerSender, null));
                 FUtil.bcastMsg(playerSender.getName() + " joined the game.", ChatColor.YELLOW);
-                plugin.dc.messageChatChannel("**" + playerSender.getName() + " joined the server" + "**");
+                plugin.dc.messageChatChannel("**" + playerSender.getName() + " joined the server" + "**", true);
             }
 
             PlayerData playerData = plugin.pl.getData(playerSender);
@@ -91,7 +91,7 @@ public class Command_vanish extends FreedomCommand
             {
                 msg("You have vanished.", ChatColor.GOLD);
                 FUtil.bcastMsg(playerSender.getName() + " left the game.", ChatColor.YELLOW);
-                plugin.dc.messageChatChannel("**" + playerSender.getName() + " left the server" + "**");
+                plugin.dc.messageChatChannel("**" + playerSender.getName() + " left the server" + "**", true);
             }
 
             FLog.info(playerSender.getName() + " is now vanished.");

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/FreedomCommand.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/FreedomCommand.java
@@ -1,14 +1,10 @@
 package me.totalfreedom.totalfreedommod.command;
 
 import com.google.common.collect.Lists;
+
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.*;
+
 import me.totalfreedom.totalfreedommod.TotalFreedomMod;
 import me.totalfreedom.totalfreedommod.admin.Admin;
 import me.totalfreedom.totalfreedommod.player.PlayerData;
@@ -18,12 +14,14 @@ import me.totalfreedom.totalfreedommod.util.FUtil;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.Server;
 import org.bukkit.command.*;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class FreedomCommand implements CommandExecutor, TabCompleter
 {
@@ -227,6 +225,16 @@ public abstract class FreedomCommand implements CommandExecutor, TabCompleter
             }
         }
         return player;
+    }
+
+    @Nullable
+    protected OfflinePlayer getOfflinePlayer(String name)
+    {
+        return Arrays.stream(Bukkit.getOfflinePlayers())
+                .filter(player -> player.getName() != null)
+                .filter(player -> player.getName().equalsIgnoreCase(name))
+                .findFirst()
+                .orElse(null);
     }
 
     protected Admin getAdmin(CommandSender sender)

--- a/src/main/java/me/totalfreedom/totalfreedommod/config/ConfigEntry.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/config/ConfigEntry.java
@@ -74,7 +74,9 @@ public enum ConfigEntry
     SERVER_FULL_MOTD(String.class, "server.motds.full"),
     //
     DISCORD_TOKEN(String.class, "discord.token"),
+    DISCORD_PREFIX(String.class, "discord.prefix"),
     DISCORD_REPORT_CHANNEL_ID(String.class, "discord.report_channel_id"),
+    DISCORD_REPORT_ARCHIVE_CHANNEL_ID(String.class, "discord.report_archive_channel_id"),
     DISCORD_CHAT_CHANNEL_ID(String.class, "discord.chat_channel_id"),
     DISCORD_ADMINCHAT_CHANNEL_ID(String.class, "discord.adminchat_channel_id"),
 

--- a/src/main/java/me/totalfreedom/totalfreedommod/discord/MessageReactionListener.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/discord/MessageReactionListener.java
@@ -1,0 +1,68 @@
+package me.totalfreedom.totalfreedommod.discord;
+
+import me.totalfreedom.totalfreedommod.config.ConfigEntry;
+import me.totalfreedom.totalfreedommod.util.FLog;
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+public class MessageReactionListener extends ListenerAdapter
+{
+    public void onMessageReactionAdd(MessageReactionAddEvent messageReactionAddEvent)
+    {
+        if (!messageReactionAddEvent.isFromGuild())
+        {
+            return;
+        }
+
+        if (messageReactionAddEvent.getMember() == null)
+        {
+            return;
+        }
+
+        if (messageReactionAddEvent.getMember().getUser().getId().equals(Discord.bot.getSelfUser().getId()))
+        {
+            return;
+        }
+
+        if (!messageReactionAddEvent.getChannel().getId().equals(ConfigEntry.DISCORD_REPORT_CHANNEL_ID.getString()))
+        {
+            return;
+        }
+
+        if (!messageReactionAddEvent.getReactionEmote().getEmoji().equals("\uD83D\uDCCB"))
+        {
+            return;
+        }
+
+        final TextChannel archiveChannel = Discord.bot.getTextChannelById(ConfigEntry.DISCORD_REPORT_ARCHIVE_CHANNEL_ID.getString());
+
+        if (archiveChannel == null)
+        {
+            FLog.warning("Report archive channel is defined in the config, yet doesn't actually exist!");
+            return;
+        }
+
+        final Message message = messageReactionAddEvent.retrieveMessage().complete();
+        final Member completer = messageReactionAddEvent.getMember();
+
+        if (!message.getAuthor().getId().equals(Discord.bot.getSelfUser().getId()))
+        {
+            return;
+        }
+
+        // We don't need other embeds... yet?
+        final MessageEmbed embed = message.getEmbeds().get(0);
+        final MessageBuilder archiveMessageBuilder = new MessageBuilder();
+        archiveMessageBuilder.setContent("Report completed by " + completer.getUser().getAsMention() + " (" + Discord.deformat(completer.getUser().getAsTag() + ")"));
+        archiveMessageBuilder.setEmbed(embed);
+        final Message archiveMessage = archiveMessageBuilder.build();
+
+        archiveChannel.sendMessage(archiveMessage).complete();
+        message.delete().complete();
+    }
+}

--- a/src/main/java/me/totalfreedom/totalfreedommod/discord/command/DiscordCommand.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/discord/command/DiscordCommand.java
@@ -1,0 +1,25 @@
+package me.totalfreedom.totalfreedommod.discord.command;
+
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.User;
+
+import java.util.List;
+
+public interface DiscordCommand
+{
+    String getCommandName();
+
+    String getDescription();
+
+    String getCategory();
+
+    List<String> getAliases();
+
+    boolean isAdmin();
+
+    boolean canExecute(Member member);
+
+    MessageBuilder execute(Member member, List<String> args);
+}

--- a/src/main/java/me/totalfreedom/totalfreedommod/discord/command/DiscordCommandImpl.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/discord/command/DiscordCommandImpl.java
@@ -1,0 +1,13 @@
+package me.totalfreedom.totalfreedommod.discord.command;
+
+import net.dv8tion.jda.api.entities.Member;
+
+public abstract class DiscordCommandImpl implements DiscordCommand
+{
+    @Override
+    public boolean canExecute(Member member)
+    {
+        //return !isAdmin() || member.getRoles().stream().filter((role -> role.getName().toLowerCase().contains("admin") && !role.getName().toLowerCase().contains("discord"))).toList().size() > 0;
+        return !isAdmin();
+    }
+}

--- a/src/main/java/me/totalfreedom/totalfreedommod/discord/command/DiscordCommandManager.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/discord/command/DiscordCommandManager.java
@@ -1,0 +1,84 @@
+package me.totalfreedom.totalfreedommod.discord.command;
+
+import me.totalfreedom.totalfreedommod.config.ConfigEntry;
+import me.totalfreedom.totalfreedommod.discord.Discord;
+import me.totalfreedom.totalfreedommod.util.FLog;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.TextChannel;
+import org.reflections.Reflections;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+public class DiscordCommandManager
+{
+    public static final String PREFIX = ConfigEntry.DISCORD_PREFIX.getString();
+    private Discord discord;
+    public final List<DiscordCommand> commands = new ArrayList<>();
+
+    public void init(Discord discord)
+    {
+        this.discord = discord;
+
+        final Reflections discordCommandsDir = new Reflections("me.totalfreedom.totalfreedommod.discord.commands");
+
+        final Set<Class<? extends DiscordCommand>> commandClasses = discordCommandsDir.getSubTypesOf(DiscordCommand.class);
+
+        for (Class<? extends DiscordCommand> commandClass : commandClasses)
+        {
+            try
+            {
+                commands.add(commandClass.getDeclaredConstructor().newInstance());
+            }
+            catch (Exception e)
+            {
+                FLog.warning("Failed to load Discord command: " + commandClass.getName());
+            }
+        }
+
+        FLog.info("Loaded " + commands.size() + " Discord commands.");
+    }
+
+    public void parse(String content, Member member, TextChannel channel)
+    {
+        List<String> args = new ArrayList<>(Arrays.asList(content.split(" ")));
+
+        final String alias = args.remove(0).split(PREFIX)[1]; // The joys of command parsing
+
+        for (DiscordCommand command : commands)
+        {
+            if (command.getCommandName().equalsIgnoreCase(alias) || command.getAliases().contains(alias.toLowerCase()))
+            {
+                if (command.canExecute(member))
+                {
+                    final MessageBuilder messageBuilder = command.execute(member, args);
+                    final Message message = messageBuilder.build();
+                    final CompletableFuture<Message> futureMessage = channel.sendMessage(message).submit(true);
+
+                    this.discord.sentMessages.add(futureMessage);
+                }
+                else
+                {
+                    final MessageBuilder messageBuilder = new MessageBuilder();
+                    final EmbedBuilder embedBuilder = new EmbedBuilder();
+                    embedBuilder.setTitle("Command error");
+                    embedBuilder.setColor(Color.RED);
+                    embedBuilder.setDescription("You don't have permission to execute this command.");
+                    messageBuilder.setEmbed(embedBuilder.build());
+                    final Message message = messageBuilder.build();
+
+                    final CompletableFuture<Message> futureMessage = channel.sendMessage(message).submit(true);
+
+                    this.discord.sentMessages.add(futureMessage);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/me/totalfreedom/totalfreedommod/discord/commands/HelpCommand.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/discord/commands/HelpCommand.java
@@ -1,0 +1,86 @@
+package me.totalfreedom.totalfreedommod.discord.commands;
+
+import me.totalfreedom.totalfreedommod.discord.Discord;
+import me.totalfreedom.totalfreedommod.discord.command.DiscordCommand;
+import me.totalfreedom.totalfreedommod.discord.command.DiscordCommandImpl;
+import me.totalfreedom.totalfreedommod.discord.command.DiscordCommandManager;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.Member;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class HelpCommand extends DiscordCommandImpl
+{
+    @Override
+    public String getCommandName()
+    {
+        return "help";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Displays the help command";
+    }
+
+    @Override
+    public String getCategory()
+    {
+        return "Help";
+    }
+
+    @Override
+    public List<String> getAliases()
+    {
+        return List.of("cmds", "commands", "elp");
+    }
+
+    @Override
+    public boolean isAdmin()
+    {
+        return false;
+    }
+
+    @Override
+    public MessageBuilder execute(Member member, List<String> args)
+    {
+        final EmbedBuilder embedBuilder = new EmbedBuilder();
+        embedBuilder.setColor(Color.GREEN);
+        embedBuilder.setTitle("Help Command");
+
+        final Map<String, List<DiscordCommand>> commandCategories = new HashMap<>();
+
+        for (DiscordCommand command : Discord.DISCORD_COMMAND_MANAGER.commands)
+        {
+            if (!commandCategories.containsKey(command.getCategory()))
+            {
+                commandCategories.put(command.getCategory(), new ArrayList<>(List.of(command)));
+            }
+            else
+            {
+                commandCategories.get(command.getCategory()).add(command);
+            }
+        }
+
+        for (Map.Entry<String, List<DiscordCommand>> entry : commandCategories.entrySet())
+        {
+            final String category = entry.getKey();
+            final List<DiscordCommand> commands = entry.getValue();
+            final StringBuilder fieldValue = new StringBuilder();
+
+            for (DiscordCommand command : commands)
+            {
+                fieldValue.append("**").append(DiscordCommandManager.PREFIX).append(command.getCommandName()).append("** - ").append(command.getDescription()).append("\n");
+            }
+
+            embedBuilder.addField(category, fieldValue.toString().trim(), false);
+        }
+
+        return new MessageBuilder().setEmbed(embedBuilder.build());
+    }
+}

--- a/src/main/java/me/totalfreedom/totalfreedommod/discord/commands/ListCommand.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/discord/commands/ListCommand.java
@@ -1,0 +1,106 @@
+package me.totalfreedom.totalfreedommod.discord.commands;
+
+import me.totalfreedom.totalfreedommod.TotalFreedomMod;
+import me.totalfreedom.totalfreedommod.admin.AdminList;
+import me.totalfreedom.totalfreedommod.config.ConfigEntry;
+import me.totalfreedom.totalfreedommod.discord.command.DiscordCommand;
+import me.totalfreedom.totalfreedommod.discord.command.DiscordCommandImpl;
+import me.totalfreedom.totalfreedommod.rank.Displayable;
+import me.totalfreedom.totalfreedommod.rank.RankManager;
+import me.totalfreedom.totalfreedommod.util.FUtil;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.User;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ListCommand extends DiscordCommandImpl
+{
+    private static final TotalFreedomMod PLUGIN = TotalFreedomMod.plugin();
+
+    @Override
+    public String getCommandName()
+    {
+        return "list";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Gives a list of online players.";
+    }
+
+    @Override
+    public String getCategory()
+    {
+        return "Server Commands";
+    }
+
+    @Override
+    public List<String> getAliases()
+    {
+        return List.of("online", "who", "l", "lsit");
+    }
+
+    @Override
+    public boolean isAdmin()
+    {
+        return false;
+    }
+
+    @Override
+    public MessageBuilder execute(Member member, List<String> args)
+    {
+        if (PLUGIN == null)
+        {
+            throw new IllegalStateException("TotalFreedomMod somehow null while executing a command!");
+        }
+
+        final AdminList adminList = PLUGIN.al;
+        final RankManager rankManager = PLUGIN.rm;
+
+        EmbedBuilder embedBuilder = new EmbedBuilder()
+                .setTitle("Player List - " + ConfigEntry.SERVER_NAME.getString())
+                .setDescription("There are " + FUtil.getFakePlayerCount() + " / " + Bukkit.getMaxPlayers() + " online players");
+
+        Map<Displayable, List<String>> displayables = new HashMap<>();
+
+        for (Player onlinePlayer : Bukkit.getOnlinePlayers())
+        {
+            if (adminList.isVanished(onlinePlayer.getName()))
+            {
+                continue;
+            }
+
+
+            Displayable displayable = rankManager.getDisplay(onlinePlayer);
+
+            if (displayables.containsKey(displayable))
+            {
+                displayables.get(displayable).add(onlinePlayer.getName());
+            }
+            else
+            {
+                displayables.put(displayable, new ArrayList<>(List.of(onlinePlayer.getName())));
+            }
+        }
+
+        for (Map.Entry<Displayable, List<String>> entry : displayables.entrySet())
+        {
+            final Displayable displayable = entry.getKey();
+            final List<String> players = entry.getValue();
+
+            embedBuilder.addField(displayable.getPlural() + " (" + players.size() + ")",
+                    String.join(", ", players), false);
+        }
+
+        return new MessageBuilder().setEmbed(embedBuilder.build());
+    }
+}

--- a/src/main/java/me/totalfreedom/totalfreedommod/discord/commands/TPSCommand.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/discord/commands/TPSCommand.java
@@ -1,0 +1,60 @@
+package me.totalfreedom.totalfreedommod.discord.commands;
+
+import me.totalfreedom.totalfreedommod.discord.command.DiscordCommand;
+import me.totalfreedom.totalfreedommod.discord.command.DiscordCommandImpl;
+import me.totalfreedom.totalfreedommod.util.FUtil;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.Member;
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+
+import java.util.Collections;
+import java.util.List;
+
+public class TPSCommand extends DiscordCommandImpl
+{
+    @Override
+    public String getCommandName()
+    {
+        return "tps";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Lag information regarding the server.";
+    }
+
+    @Override
+    public String getCategory()
+    {
+        return "Server Commands";
+    }
+
+    @Override
+    public List<String> getAliases()
+    {
+        return Collections.singletonList("lag");
+    }
+
+    @Override
+    public boolean isAdmin()
+    {
+        return false;
+    }
+
+    @Override
+    public MessageBuilder execute(Member member, List<String> args)
+    {
+        final EmbedBuilder builder = new EmbedBuilder();
+        builder.setTitle("Server lag information");
+        builder.addField("TPS", String.valueOf(Math.round(FUtil.getMeanAverageDouble(Bukkit.getServer().getTPS()))), false);
+        builder.addField("Uptime", FUtil.getUptime(), false);
+        builder.addField("Maximum Memory", Math.ceil(FUtil.getMaxMem()) + " MB", false);
+        builder.addField("Allocated Memory", Math.ceil(FUtil.getTotalMem()) + " MB", false);
+        builder.addField("Free Memory", Math.ceil(FUtil.getFreeMem()) + " MB", false);
+
+        return new MessageBuilder().setEmbed(builder.build());
+    }
+}

--- a/src/main/java/me/totalfreedom/totalfreedommod/discord/commands/UptimeCommand.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/discord/commands/UptimeCommand.java
@@ -1,0 +1,79 @@
+package me.totalfreedom.totalfreedommod.discord.commands;
+
+import me.totalfreedom.totalfreedommod.discord.command.DiscordCommandImpl;
+import me.totalfreedom.totalfreedommod.util.FLog;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.Member;
+
+import java.awt.*;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.List;
+
+public class UptimeCommand extends DiscordCommandImpl
+{
+    @Override
+    public String getCommandName()
+    {
+        return "uptime";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Returns the uptime of the host.";
+    }
+
+    @Override
+    public String getCategory()
+    {
+        return "Server Commands";
+    }
+
+    @Override
+    public List<String> getAliases()
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isAdmin()
+    {
+        return false;
+    }
+
+    @Override
+    public MessageBuilder execute(Member member, List<String> args)
+    {
+        final EmbedBuilder embedBuilder = new EmbedBuilder();
+
+        try
+        {
+            final Process uptimeProcess = Runtime.getRuntime().exec(new String[]{"uptime"});
+            BufferedReader input = new BufferedReader(new InputStreamReader(uptimeProcess.getInputStream()));
+            String line = input.readLine();
+
+            if (line != null)
+            {
+                embedBuilder.setTitle("Host Uptime Information");
+                embedBuilder.setDescription(line.trim());
+            }
+            else
+            {
+                throw new IllegalStateException("No output from uptime command.");
+            }
+        }
+        catch (Exception e)
+        {
+            FLog.warning("Error while executing uptime Discord command");
+            e.printStackTrace();
+            embedBuilder.setTitle("Command error");
+            embedBuilder.setColor(Color.RED);
+            embedBuilder.setDescription("Something went wrong");
+        }
+
+        return new MessageBuilder().setEmbed(embedBuilder.build());
+    }
+}

--- a/src/main/java/me/totalfreedom/totalfreedommod/rank/Displayable.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/rank/Displayable.java
@@ -13,6 +13,8 @@ public interface Displayable
 
     String getAbbr();
 
+    String getPlural();
+
     ChatColor getColor();
 
     org.bukkit.ChatColor getTeamColor();

--- a/src/main/java/me/totalfreedom/totalfreedommod/rank/Rank.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/rank/Rank.java
@@ -4,19 +4,19 @@ import net.md_5.bungee.api.ChatColor;
 
 public enum Rank implements Displayable
 {
-    NON_OP("a", "Non-Op", Type.PLAYER, "", ChatColor.WHITE, null, false, false),
-    OP("an", "Operator", Type.PLAYER, "OP", ChatColor.GREEN, null, false, false),
-    ADMIN("an", "Admin", Type.ADMIN, "Admin", ChatColor.DARK_GREEN, org.bukkit.ChatColor.DARK_GREEN, true, true),
-    SENIOR_ADMIN("a", "Senior Admin", Type.ADMIN, "SrA", ChatColor.GOLD, org.bukkit.ChatColor.GOLD, true, true),
-    ADMIN_CONSOLE("the", "Console", Type.ADMIN_CONSOLE, "Console", ChatColor.DARK_PURPLE, null, false, false),
-    SENIOR_CONSOLE("the", "Console", Type.ADMIN_CONSOLE, "Console", ChatColor.DARK_PURPLE, null, false, false);
+    NON_OP("a", "Non-Op", Type.PLAYER, "", "Non-Ops", ChatColor.WHITE, null, false, false),
+    OP("an", "Operator", Type.PLAYER, "OP", "Operators", ChatColor.GREEN, null, false, false),
+    ADMIN("an", "Admin", Type.ADMIN, "Admin", "Administrators", ChatColor.DARK_GREEN, org.bukkit.ChatColor.DARK_GREEN, true, true),
+    SENIOR_ADMIN("a", "Senior Admin", Type.ADMIN, "SrA", "Senior Administrators", ChatColor.GOLD, org.bukkit.ChatColor.GOLD, true, true),
+    ADMIN_CONSOLE("the", "Console", Type.ADMIN_CONSOLE, "Console", "Administrator Consoles", ChatColor.DARK_PURPLE, null, false, false),
+    SENIOR_CONSOLE("the", "Console", Type.ADMIN_CONSOLE, "Console", "Senior Consoles", ChatColor.DARK_PURPLE, null, false, false);
 
     private final Type type;
 
     private final String name;
 
     private final String abbr;
-
+    private final String plural;
     private final String article;
 
     private final String tag;
@@ -31,11 +31,12 @@ public enum Rank implements Displayable
 
     private final boolean hasDefaultLoginMessage;
 
-    Rank(String article, String name, Type type, String abbr, ChatColor color, org.bukkit.ChatColor teamColor, Boolean hasTeam, Boolean hasDefaultLoginMessage)
+    Rank(String article, String name, Type type, String abbr, String plural, ChatColor color, org.bukkit.ChatColor teamColor, Boolean hasTeam, Boolean hasDefaultLoginMessage)
     {
         this.type = type;
         this.name = name;
         this.abbr = abbr;
+        this.plural = plural;
         this.article = article;
         this.tag = abbr.isEmpty() ? "" : "[" + abbr + "]";
         this.coloredTag = abbr.isEmpty() ? "" : ChatColor.DARK_GRAY + "[" + color + abbr + ChatColor.DARK_GRAY + "]" + color;
@@ -86,6 +87,11 @@ public enum Rank implements Displayable
     public String getAbbr()
     {
         return abbr;
+    }
+
+    public String getPlural()
+    {
+        return plural;
     }
 
     public boolean isConsole()

--- a/src/main/java/me/totalfreedom/totalfreedommod/rank/Title.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/rank/Title.java
@@ -5,11 +5,11 @@ import net.md_5.bungee.api.ChatColor;
 public enum Title implements Displayable
 {
 
-    MASTER_BUILDER("a", "Master Builder", ChatColor.DARK_AQUA, org.bukkit.ChatColor.DARK_AQUA, "MB", true, true),
-    EXECUTIVE("an", "Executive", ChatColor.RED, org.bukkit.ChatColor.RED, "Exec", true, true),
-    ASSTEXEC("an", "Assistant Executive", ChatColor.RED, org.bukkit.ChatColor.RED, "Asst Exec", true, true),
-    DEVELOPER("a", "Developer", ChatColor.DARK_PURPLE, org.bukkit.ChatColor.DARK_PURPLE, "Dev", true, true),
-    OWNER("the", "Owner", ChatColor.DARK_RED, org.bukkit.ChatColor.DARK_RED, "Owner", true, true);
+    MASTER_BUILDER("a", "Master Builder", "Master Builders", ChatColor.DARK_AQUA, org.bukkit.ChatColor.DARK_AQUA, "MB", true, true),
+    EXECUTIVE("an", "Executive", "Executives", ChatColor.RED, org.bukkit.ChatColor.RED, "Exec", true, true),
+    ASSTEXEC("an", "Assistant Executive", "Assistant Executives", ChatColor.RED, org.bukkit.ChatColor.RED, "Asst Exec", true, true),
+    DEVELOPER("a", "Developer", "Developers", ChatColor.DARK_PURPLE, org.bukkit.ChatColor.DARK_PURPLE, "Dev", true, true),
+    OWNER("the", "Owner", "Owners", ChatColor.DARK_RED, org.bukkit.ChatColor.DARK_RED, "Owner", true, true);
 
 
     private final String article;
@@ -17,6 +17,7 @@ public enum Title implements Displayable
     private final String name;
 
     private final String abbr;
+    private final String plural;
 
     private final String tag;
 
@@ -29,10 +30,11 @@ public enum Title implements Displayable
     private final boolean hasTeam;
     private final boolean hasDefaultLoginMessage;
 
-    Title(String article, String name, ChatColor color, org.bukkit.ChatColor teamColor, String tag, Boolean hasTeam, Boolean hasDefaultLoginMessage)
+    Title(String article, String name, String plural, ChatColor color, org.bukkit.ChatColor teamColor, String tag, Boolean hasTeam, Boolean hasDefaultLoginMessage)
     {
         this.article = article;
         this.name = name;
+        this.plural = plural;
         this.coloredTag = ChatColor.DARK_GRAY + "[" + color + tag + ChatColor.DARK_GRAY + "]" + color;
         this.abbr = tag;
         this.tag = "[" + tag + "]";
@@ -82,6 +84,12 @@ public enum Title implements Displayable
     public String getAbbr()
     {
         return abbr;
+    }
+
+    @Override
+    public String getPlural()
+    {
+        return plural;
     }
 
     @Override

--- a/src/main/java/me/totalfreedom/totalfreedommod/util/FUtil.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/util/FUtil.java
@@ -1,16 +1,12 @@
 package me.totalfreedom.totalfreedommod.util;
 
+import com.earth2me.essentials.utils.DateUtil;
 import me.totalfreedom.totalfreedommod.TotalFreedomMod;
 import me.totalfreedom.totalfreedommod.config.ConfigEntry;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.WordUtils;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Color;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
+import org.bukkit.*;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -19,10 +15,9 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
-import org.json.simple.JSONArray;
 
 import java.io.*;
-import java.lang.reflect.Field;
+import java.lang.management.ManagementFactory;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.text.ParseException;
@@ -550,6 +545,11 @@ public class FUtil
         return string;
     }
 
+    public static String stripColors(String string)
+    {
+        return string.replaceAll("§", "");
+    }
+
     public static Date getUnixDate(long unix)
     {
         return new Date(unix);
@@ -793,6 +793,62 @@ public class FUtil
             }
         }
         return getServer().getOnlinePlayers().size() - i;
+    }
+
+    public static double getMeanAverageDouble(double[] doubles)
+    {
+        double total = 0;
+
+        for (double aDouble : doubles)
+        {
+            total += aDouble;
+        }
+
+        return total / doubles.length;
+    }
+
+    public static int getMeanAverageInt(int[] ints)
+    {
+        int total = 0;
+
+        for (int anInt : ints)
+        {
+            total += anInt;
+        }
+
+        return total / ints.length;
+    }
+
+    public static long getMeanAverageLong(long[] longs)
+    {
+        long total = 0;
+
+        for (long aLong : longs)
+        {
+            total += aLong;
+        }
+
+        return total / longs.length;
+    }
+
+    public static String getUptime()
+    {
+        return DateUtil.formatDateDiff(ManagementFactory.getRuntimeMXBean().getStartTime());
+    }
+
+    public static double getMaxMem()
+    {
+        return Runtime.getRuntime().maxMemory() / 1024f / 1024f;
+    }
+
+    public static double getTotalMem()
+    {
+        return Runtime.getRuntime().totalMemory() / 1024f / 1024f;
+    }
+
+    public static double getFreeMem()
+    {
+        return Runtime.getRuntime().freeMemory() / 1024f / 1024f;
     }
 
     public static class PaginationList<T> extends ArrayList<T>

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -58,10 +58,14 @@ server:
 discord:
   # If you do not have a token, make a bot account and get one at https://discordapp.com/developers/applications/me
   token: ''
+  # The prefix for the integrated bot commands
+  prefix: 'tf!'
   # The official discord server's ID for this server
   server_id: ''
   # Channel to send /report messages to
   report_channel_id: ''
+  # Channel to send archived reports to
+  report_archive_channel_id: ''
   # Channel for Discord to Minecraft and vice-versa
   chat_channel_id: ''
   # Channel for Discord to AdminChat and vice-versa


### PR DESCRIPTION
(changed branch so the action hopefully runs)

Includes:
- tps
- uptime
- help
- list
- Report archival (suggested by Tizz91)

Others aren't implemented as, to my knowledge, we have better solutions already.

Fixes:
- Players being able to mention anyone with a special symbols Discord ignores
- Players being able to use markdown in chat and it not being sanitized by the bot
- Players being able to use section signs in their nicknames
- Discord members being able to use section signs in their messages, even though we had a patch in place for that
- Using a deprecated method of fetching the death message

Other Changes:
- Moved what we were doing before to sanitize discord messages into its own method (we were doing the same code in the admin chat and regular player chat without calling a function)
- Replaced a nested if statement tree with guard clauses in DiscordToMinecraftListener for better readability
- Added mean averaging to FUtil (implemented to get the average TPS for the tps command)
- Added methods for getting max memory, used memory and free memory in FUtil (implemented for the tps command)
- Switched over from adding random numbers to generate a code to using RandomStringUtils.randomNumeric