### PR TITLE
FS-454 - Add expiry to indefinite bans

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/banning/IndefiniteBan.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/banning/IndefiniteBan.java
@@ -1,10 +1,14 @@
 package me.totalfreedom.totalfreedommod.banning;
 
 import com.google.common.collect.Lists;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import me.totalfreedom.totalfreedommod.config.IConfig;
 import me.totalfreedom.totalfreedommod.util.FLog;
+import me.totalfreedom.totalfreedommod.util.FUtil;
 import org.bukkit.configuration.ConfigurationSection;
 
 public class IndefiniteBan implements IConfig
@@ -13,6 +17,7 @@ public class IndefiniteBan implements IConfig
     private String username = null;
     private UUID uuid = null;
     private String reason = null;
+    private Date expiry = null;
 
     public IndefiniteBan()
     {
@@ -22,6 +27,7 @@ public class IndefiniteBan implements IConfig
     public void loadFrom(ConfigurationSection cs)
     {
         this.username = cs.getName();
+
         try
         {
             String strUUID = cs.getString("uuid", null);
@@ -35,9 +41,20 @@ public class IndefiniteBan implements IConfig
         {
             FLog.warning("Failed to load indefinite banned UUID for " + this.username + ". Make sure the UUID is in the correct format with dashes.");
         }
+
         this.ips.clear();
         this.ips.addAll(cs.getStringList("ips"));
         this.reason = cs.getString("reason", null);
+
+        String date = cs.getString("expiry", null);
+        try
+        {
+            this.expiry = date != null ? new SimpleDateFormat("yyyy-MM-dd").parse(date) : null;
+        }
+        catch (ParseException ex)
+        {
+            FLog.warning("Failed to load indefinite banned expiry for " + this.username + ". Make sure the expiry is in the correct format (yyyy-MM-dd).");
+        }
     }
 
     @Override
@@ -85,5 +102,25 @@ public class IndefiniteBan implements IConfig
     public void setReason(String reason)
     {
         this.reason = reason;
+    }
+
+    public Date getExpiry()
+    {
+        return expiry;
+    }
+
+    public void setExpiry(Date date)
+    {
+        this.expiry = date;
+    }
+
+    public boolean hasExpiry()
+    {
+        return this.expiry != null;
+    }
+
+    public boolean isExpired()
+    {
+        return hasExpiry() && expiry.before(new Date(FUtil.getUnixTime()));
     }
 }

--- a/src/main/java/me/totalfreedom/totalfreedommod/banning/IndefiniteBanList.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/banning/IndefiniteBanList.java
@@ -122,7 +122,9 @@ public class IndefiniteBanList extends FreedomService
                 return;
             }
 
-            String kickMessage = ChatColor.RED + "Your " + bannedBy + " is indefinitely banned from this server.";
+            String kickMessage = ChatColor.RED + "Your " + bannedBy + " is "
+                + (ban.hasExpiry() ? "" : "indefinitely ")
+                + "banned from this server.";
             String reason = ban.getReason();
             if (!Strings.isNullOrEmpty(reason))
             {

--- a/src/main/java/me/totalfreedom/totalfreedommod/banning/IndefiniteBanList.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/banning/IndefiniteBanList.java
@@ -2,6 +2,8 @@ package me.totalfreedom.totalfreedommod.banning;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Set;
 import java.util.UUID;
 import me.totalfreedom.totalfreedommod.FreedomService;
@@ -19,30 +21,24 @@ public class IndefiniteBanList extends FreedomService
 {
 
     public static final String CONFIG_FILENAME = "indefinitebans.yml";
-
+    private YamlConfig config;
 
     private final Set<IndefiniteBan> indefBans = Sets.newHashSet();
 
-
     private int nameBanCount = 0;
-
 
     private int uuidBanCount = 0;
 
-
     private int ipBanCount = 0;
 
-    public static String getConfigFilename()
-    {
-        return CONFIG_FILENAME;
-    }
+    private final SimpleDateFormat dateFormat = new SimpleDateFormat("dd MMM yyyy, zzzz");
 
     @Override
     public void onStart()
     {
         indefBans.clear();
 
-        final YamlConfig config = new YamlConfig(plugin, CONFIG_FILENAME, true);
+        config = new YamlConfig(plugin, CONFIG_FILENAME, true);
         config.load();
 
         for (String name : config.getKeys(false))
@@ -64,10 +60,18 @@ public class IndefiniteBanList extends FreedomService
                 continue;
             }
 
+            if (indefBan.isExpired())
+            {
+                FLog.info("Removing " + name + " from indefinite ban list as the entry has expired!");
+                config.set(name, null);
+                continue;
+            }
+
             indefBans.add(indefBan);
         }
 
         updateCount();
+        config.save();
 
         FLog.info("Loaded " + nameBanCount + " indefinite name bans, " + uuidBanCount + " UUID bans, and " + ipBanCount + " ip bans");
     }
@@ -111,12 +115,26 @@ public class IndefiniteBanList extends FreedomService
 
         if (ban != null)
         {
+            if (ban.isExpired())
+            {
+                config.set(ban.getUsername(), null);
+                config.save();
+                return;
+            }
+
             String kickMessage = ChatColor.RED + "Your " + bannedBy + " is indefinitely banned from this server.";
             String reason = ban.getReason();
             if (!Strings.isNullOrEmpty(reason))
             {
                 kickMessage += "\nReason: " + ChatColor.GOLD + reason;
             }
+
+            Date expiry = ban.getExpiry();
+            if (expiry != null)
+            {
+                kickMessage += ChatColor.RED + "\nExpiry: " + ChatColor.GOLD + dateFormat.format(expiry);
+            }
+
             String appealURL = ConfigEntry.SERVER_INDEFBAN_URL.getString();
             if (!Strings.isNullOrEmpty(appealURL))
             {

--- a/src/main/java/me/totalfreedom/totalfreedommod/config/IConfig.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/config/IConfig.java
@@ -1,11 +1,10 @@
 package me.totalfreedom.totalfreedommod.config;
 
-import java.text.ParseException;
 import org.bukkit.configuration.ConfigurationSection;
 
 public interface IConfig
 {
-    void loadFrom(ConfigurationSection cs) throws ParseException;
+    void loadFrom(ConfigurationSection cs);
 
     void saveTo(ConfigurationSection cs);
 

--- a/src/main/java/me/totalfreedom/totalfreedommod/config/IConfig.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/config/IConfig.java
@@ -1,10 +1,11 @@
 package me.totalfreedom.totalfreedommod.config;
 
+import java.text.ParseException;
 import org.bukkit.configuration.ConfigurationSection;
 
 public interface IConfig
 {
-    void loadFrom(ConfigurationSection cs);
+    void loadFrom(ConfigurationSection cs) throws ParseException;
 
     void saveTo(ConfigurationSection cs);
 


### PR DESCRIPTION
This will allow people to add expiry to indefinite bans, which will be deleted after midnight on a specified date.
The date format is set to `yyyy-MM-dd` to avoid confusion between the US and Europe dating conventions.

When the expiry date shows up on the ban screen, it'll contain the timezone to avoid confusion, with some players thinking the date may be in their timezone.

The indefinite ban screen when a user joins will show expiry if they aren't banned permanently:
![](https://media.deafkid.dev/tqc35n1v.png)

No expiry:
![](https://media.deafkid.dev/frnmnwcb.png)

--

In the `indefinitebans.yml` file, the date must be enclosed with the quotation marks `'`... Otherwise, the expiry won't be parsed and will be treated as a permanent ban - a warning will throw about the date format if this occurs. For example:

Valid entry:
```yaml
NotInSync:
  ips:
  - 127.0.0.1
  reason: Test Indef Ban with no expiry
  expiry: '2022-10-29'
```
  
  Invalid entry:
  ```yaml
NotInSync:
  ips:
  - 127.0.0.1
  reason: Test Indef Ban with no expiry
  expiry: 2022-10-29
```