### PR TITLE
Minor Changes to TFM Ops and Admins have Suggested

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_blockredstone.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_blockredstone.java
@@ -9,7 +9,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
 @CommandPermissions(level = Rank.ADMIN, source = SourceType.BOTH)
-@CommandParameters(description = "Blocks redstone on the server.", usage = "/<command>", aliases = "bre")
+@CommandParameters(description = "Blocks redstone on the server.", usage = "/<command>", aliases = "bre,toggleredstone")
 public class Command_blockredstone extends FreedomCommand
 {
 

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_cleanchat.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_cleanchat.java
@@ -7,7 +7,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 @CommandPermissions(level = Rank.ADMIN, source = SourceType.BOTH)
-@CommandParameters(description = "Clears the chat.", usage = "/<command>", aliases = "cc")
+@CommandParameters(description = "Clears the chat.", usage = "/<command>", aliases = "cc,clearchat")
 public class Command_cleanchat extends FreedomCommand
 {
     @Override

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_purgeall.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_purgeall.java
@@ -20,7 +20,8 @@ public class Command_purgeall extends FreedomCommand
     public boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
     {
         FUtil.adminAction(sender.getName(), "Purging all player data", true);
-
+        
+        //TODO Make Purgeall not include Item frames and Paintings.
         // Purge entities
         for (World world : Bukkit.getWorlds())
         {

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_rawsay.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_rawsay.java
@@ -7,7 +7,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-@CommandPermissions(level = Rank.SENIOR_ADMIN, source = SourceType.BOTH)
+@CommandPermissions(level = Rank.ADMIN, source = SourceType.BOTH)
 @CommandParameters(description = "Broadcasts the given message. Supports colors.", usage = "/<command> <message>")
 public class Command_rawsay extends FreedomCommand
 {

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_tag.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_tag.java
@@ -16,7 +16,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 @CommandPermissions(level = Rank.OP, source = SourceType.BOTH)
-@CommandParameters(description = "Allows you to set your own prefix.", usage = "/<command> [-s[ave]] <set <tag..> | list | gradient <hex> <hex> <tag..> | off | clear <player> | clearall>", aliases="prefix")
+@CommandParameters(description = "Allows you to set your own prefix.", usage = "/<command> [-s[ave]] <set <tag..> | list | gradient <hex> <hex> <tag..> | off | clear <player> | clearall>", aliases = "prefix")
 public class Command_tag extends FreedomCommand
 {
 

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_tag.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_tag.java
@@ -16,7 +16,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 @CommandPermissions(level = Rank.OP, source = SourceType.BOTH)
-@CommandParameters(description = "Allows you to set your own prefix.", usage = "/<command> [-s[ave]] <set <tag..> | list | gradient <hex> <hex> <tag..> | off | clear <player> | clearall>")
+@CommandParameters(description = "Allows you to set your own prefix.", usage = "/<command> [-s[ave]] <set <tag..> | list | gradient <hex> <hex> <tag..> | off | clear <player> | clearall>", aliases="prefix")
 public class Command_tag extends FreedomCommand
 {
 


### PR DESCRIPTION
```
Gave /rawsay to all admins
Added /prefix as an alias to /tag
Added alias /clearchat for /cleanchat as it is more identifiable
Added /toggleredstone as an alias to /blockredstone as it is more identifiable.
Added a TODO for /purgeall to not remove item frames and paintings
```
I am not an advanced programmer so I can only do so much, but I have had multiple admins/ops alike come to me with these such changes. It also helps make things easier for newer players as almost everyone tries /prefix and get's confused.

/purgeall is a great tool to help get players unstuck/remove entities from the server that can be causing lag. However, it removes item frames and paintings as well - Basically administratively griefing builds on accident. Again, I am not advanced enough to know how to do this, but I know it is a problem.